### PR TITLE
Fix compilation lint errors

### DIFF
--- a/src/test/java/net/kemitix/dependency/digraph/maven/plugin/stubs/AbstractProjectsList.java
+++ b/src/test/java/net/kemitix/dependency/digraph/maven/plugin/stubs/AbstractProjectsList.java
@@ -29,6 +29,7 @@ public abstract class AbstractProjectsList implements List<MavenProject> {
      * @param projectStub the project stub
      */
     public AbstractProjectsList(final DigraphProjectStub projectStub) {
+        projectStub.init();
         list.add(projectStub);
     }
 

--- a/src/test/java/net/kemitix/dependency/digraph/maven/plugin/stubs/DigraphProjectStub.java
+++ b/src/test/java/net/kemitix/dependency/digraph/maven/plugin/stubs/DigraphProjectStub.java
@@ -53,21 +53,24 @@ public class DigraphProjectStub extends MavenProjectStub {
         setUrl(model.getUrl());
         setPackaging(model.getPackaging());
 
+        final String srcMainJava = getBasedir() + "/src/main/java";
+        final String srcTestJava = getBasedir() + "/src/test/java";
+
         Build build = new Build();
         build.setFinalName(model.getArtifactId());
         build.setDirectory(getBasedir() + "/target");
-        build.setSourceDirectory(getBasedir() + "/src/main/java");
+        build.setSourceDirectory(srcMainJava);
         build.setOutputDirectory(getBasedir() + "/target/classes");
-        build.setTestSourceDirectory(getBasedir() + "/src/test/java");
+        build.setTestSourceDirectory(srcTestJava);
         build.setTestOutputDirectory(getBasedir() + "/target/test-classes");
         setBuild(build);
 
-        List compileSourceRoots = new ArrayList();
-        compileSourceRoots.add(getBasedir() + "/src/main/java");
+        List<String> compileSourceRoots = new ArrayList<>();
+        compileSourceRoots.add(srcMainJava);
         setCompileSourceRoots(compileSourceRoots);
 
-        List testCompileSourceRoots = new ArrayList();
-        testCompileSourceRoots.add(getBasedir() + "/src/test/java");
+        List<String> testCompileSourceRoots = new ArrayList<>();
+        testCompileSourceRoots.add(srcTestJava);
         setTestCompileSourceRoots(testCompileSourceRoots);
     }
 

--- a/src/test/java/net/kemitix/dependency/digraph/maven/plugin/stubs/DigraphProjectStub.java
+++ b/src/test/java/net/kemitix/dependency/digraph/maven/plugin/stubs/DigraphProjectStub.java
@@ -6,8 +6,10 @@ import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.apache.maven.plugin.testing.stubs.MavenProjectStub;
 import org.codehaus.plexus.util.ReaderFactory;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -28,13 +30,19 @@ public class DigraphProjectStub extends MavenProjectStub {
      */
     public DigraphProjectStub(final String path) {
         basedir = new File(super.getBasedir() + path);
+    }
+
+    /**
+     * Initialise the stub.
+     */
+    public void init() {
         MavenXpp3Reader pomReader = new MavenXpp3Reader();
         Model model;
         try {
             model = pomReader.read(ReaderFactory.newXmlReader(
                     new File(getBasedir(), "pom.xml")));
             setModel(model);
-        } catch (Exception e) {
+        } catch (IOException | XmlPullParserException e) {
             throw new RuntimeException(e);
         }
 


### PR DESCRIPTION
Remove use of raw type java.util.List and don't call overridable methods in constructor.