### PR TITLE
Add debug output tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ Add the following to you pom.xml:
                 <configuration>
                     <basePackage>com.example</basePackage>
                     <!-- <includeTests>false</includeTests> -->
+                    <!-- <debug>true</debug> -->
                 </configuration>
             </plugin>
         </plugins>
     </build>
 
-The `basePackage` is required and `includeTests` is optional, defaulting to not including them.
+The `basePackage` is required while `includeTests` and `debug` are optional. Defaults are as shown.
 

--- a/src/main/java/net/kemitix/dependency/digraph/maven/plugin/DependencyData.java
+++ b/src/main/java/net/kemitix/dependency/digraph/maven/plugin/DependencyData.java
@@ -1,6 +1,7 @@
 package net.kemitix.dependency.digraph.maven.plugin;
 
 import net.kemitix.node.Node;
+import org.apache.maven.plugin.logging.Log;
 
 /**
  * Interface for storing package and class dependency data.
@@ -31,5 +32,12 @@ interface DependencyData {
      * @return the base node
      */
     Node<PackageData> getBaseNode();
+
+    /**
+     * Log the statue of the dependency data.
+     *
+     * @param log the log to send the output
+     */
+    void debugLog(Log log);
 
 }

--- a/src/main/java/net/kemitix/dependency/digraph/maven/plugin/DigraphMojo.java
+++ b/src/main/java/net/kemitix/dependency/digraph/maven/plugin/DigraphMojo.java
@@ -30,6 +30,9 @@ public class DigraphMojo extends AbstractMojo {
     @Parameter(name = "basePackage", required = true)
     private String basePackage;
 
+    @Parameter(name = "debug", defaultValue = "true")
+    private boolean debug;
+
     private final Injector injector;
 
     private final SourceDirectoryProvider directoryProvider;
@@ -83,6 +86,9 @@ public class DigraphMojo extends AbstractMojo {
         final List<File> javaFiles = fileProvider.getJavaFiles();
         if (javaFiles != null) {
             javaFiles.forEach(fileAnalyser::analyse);
+            if (debug) {
+                dependencyData.debugLog(getLog());
+            }
             try {
                 reportWriter.write(reportGenerator.generate(
                         dependencyData.getBaseNode()), REPORT_FILE);

--- a/src/main/java/net/kemitix/dependency/digraph/maven/plugin/NodeTreeDependencyData.java
+++ b/src/main/java/net/kemitix/dependency/digraph/maven/plugin/NodeTreeDependencyData.java
@@ -3,10 +3,13 @@ package net.kemitix.dependency.digraph.maven.plugin;
 import lombok.Getter;
 import net.kemitix.node.Node;
 import net.kemitix.node.NodeItem;
+import org.apache.maven.plugin.logging.Log;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * Implementation of {@link DependencyData} using a node tree.
@@ -53,6 +56,23 @@ class NodeTreeDependencyData implements DependencyData {
         Arrays.asList(userPackage.split("\\."))
                 .forEach((String n) -> line.add(new PackageData(n)));
         return line;
+    }
+
+    @Override
+    public void debugLog(final Log log) {
+        debugLogNode(log, baseNode, 0);
+    }
+
+    private void debugLogNode(
+            final Log log,
+            final Node<PackageData> node,
+            final int depth) {
+        String padding = IntStream.range(0, depth * 2).mapToObj(x -> " ")
+                .collect(Collectors.joining());
+        log.info(padding + node.getData().getName());
+        node.getChildren().stream().forEach((Node<PackageData> t) -> {
+            debugLogNode(log, t, depth + 1);
+        });
     }
 
 }

--- a/src/test/java/net/kemitix/dependency/digraph/maven/plugin/NodeTreeDependencyDataTest.java
+++ b/src/test/java/net/kemitix/dependency/digraph/maven/plugin/NodeTreeDependencyDataTest.java
@@ -1,0 +1,81 @@
+package net.kemitix.dependency.digraph.maven.plugin;
+
+import net.kemitix.node.Node;
+import org.apache.maven.plugin.logging.Log;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link NodeTreeDependencyData}.
+ *
+ * @author pcampbell
+ */
+public class NodeTreeDependencyDataTest {
+
+    /**
+     * Class under test.
+     */
+    private NodeTreeDependencyData data;
+
+    /**
+     * Prepare each test.
+     */
+    @Before
+    public void setUp() {
+        data = new NodeTreeDependencyData();
+    }
+
+    /**
+     * Set and return the base node.
+     */
+    @Test
+    public void shouldReturnTheSetBaseNode() {
+        //given
+        data.setBasePackage("net.kemitix");
+        //when
+        Node<PackageData> baseNode = data.getBaseNode();
+        //then
+        assertThat(baseNode.getData().getName(), is("kemitix"));
+    }
+
+    /**
+     * Adding dependency creates descendant nodes.
+     */
+    @Test
+    public void shouldCreateDescendantNodes() {
+        //given
+        data.setBasePackage(("net.kemitix"));
+        final Node<PackageData> baseNode = data.getBaseNode();
+        //when
+        data.addDependency("net.kemitix.alpha", "net.kemitix.beta");
+        //then
+        assertThat(baseNode.getChild(new PackageData("alpha")).isPresent(),
+                is(true));
+        assertThat(baseNode.getChild(new PackageData("beta")).isPresent(),
+                is(true));
+    }
+
+    /**
+     * Produce debug log.
+     */
+    @Test
+    public void shouldLogDebugTree() {
+        //given
+        data.setBasePackage(("net.kemitix"));
+        data.addDependency("net.kemitix.alpha", "net.kemitix.beta");
+        Log log = mock(Log.class);
+        //when
+        data.debugLog(log);
+        //then
+        verify(log, times(1)).info("kemitix");
+        verify(log, times(1)).info("  alpha");
+        verify(log, times(1)).info("  beta");
+    }
+
+}


### PR DESCRIPTION
Adds a debug output listing the packages found:
```
[INFO] portalpasswordreset
[INFO]   test
[INFO]   core
[INFO]     event
[INFO]     SqlAction
[INFO]     Database
[INFO]   gui
[INFO]     api
[INFO]     swing
[INFO]       eventprocessor
[INFO]       netbeans
```