### PR TITLE
Fix nested node

### DIFF
--- a/src/main/java/net/kemitix/dependency/digraph/maven/plugin/DotFileFormatNested.java
+++ b/src/main/java/net/kemitix/dependency/digraph/maven/plugin/DotFileFormatNested.java
@@ -23,11 +23,13 @@ class DotFileFormatNested extends AbstractDotFileFormat {
     String renderNode(final Node<PackageData> node) {
         final StringBuilder render = new StringBuilder();
         final String clusterId = getPath(node, "_");
-        final String nodeId = node.getData().getName();
+        final String nodeId = getPath(node, ".");
+        final String nodeName = node.getData().getName();
         final String headerFormat
                 = "subgraph \"cluster{0}\"'{'"
-                + "label=\"{1}\";\"{1}\"[style=dotted]\n";
-        render.append(MessageFormat.format(headerFormat, clusterId, nodeId));
+                + "label=\"{1}\";\"{2}\"[label=\"{1}\",style=dotted]\n";
+        render.append(MessageFormat.format(
+                headerFormat, clusterId, nodeName, nodeId));
         node.getChildren().stream()
                 .sorted(new NodePackageDataComparator())
                 .forEach((Node<PackageData> child) -> {

--- a/src/test/java/net/kemitix/dependency/digraph/maven/plugin/DotFileFormatNestedTest.java
+++ b/src/test/java/net/kemitix/dependency/digraph/maven/plugin/DotFileFormatNestedTest.java
@@ -198,6 +198,65 @@ public class DotFileFormatNestedTest {
         assertThat(report, is(expected));
     }
 
+    /**
+     * The dummy package node within a package cluster should have the correct
+     * id.
+     */
+    @Test
+    public void shouldNestGrandChildParentDummyNode() {
+        //given
+        dependencyData.addDependency("test.one", "test.child.inter.leaf");
+        final Node<PackageData> baseNode = dependencyData.getBaseNode();
+
+        doReturn("test").when(nodePathGenerator)
+                .getPath(eq(baseNode), eq(baseNode), any(String.class));
+
+        Node<PackageData> oneNode = getChildNodeByName(baseNode, "one");
+        doReturn("one").when(nodePathGenerator)
+                .getPath(eq(oneNode), eq(baseNode), any(String.class));
+
+        Node<PackageData> childNode = getChildNodeByName(baseNode, "child");
+        doReturn("child").when(nodePathGenerator)
+                .getPath(eq(childNode), eq(baseNode), any(String.class));
+
+        Node<PackageData> interNode = getChildNodeByName(childNode, "inter");
+        doReturn("child.inter").when(nodePathGenerator)
+                .getPath(eq(interNode), eq(baseNode), eq("."));
+        doReturn("child_inter").when(nodePathGenerator)
+                .getPath(eq(interNode), eq(baseNode), eq("_"));
+
+        Node<PackageData> leafNode = getChildNodeByName(interNode, "leaf");
+        doReturn("child.inter.leaf").when(nodePathGenerator)
+                .getPath(eq(leafNode), eq(baseNode), eq("."));
+        doReturn("child_inter_leaf").when(nodePathGenerator)
+                .getPath(eq(leafNode), eq(baseNode), eq("_"));
+
+        final String expected = "digraph{compound=true;node[shape=box]\n"
+                + ""
+                + "subgraph \"clustertest\"{"
+                + "label=\"test\";\"test\"[style=dotted]\n"
+                + ""
+                + "subgraph \"clusterchild\"{"
+                + "label=\"child\";\"child\"[style=dotted]\n"
+                + ""
+                + "subgraph \"clusterchild_inter\"{"
+                + "label=\"inter\";"
+                + "\"child.inter\"[label=\"inter\",style=dotted]\n"
+                + ""
+                + "\"child.inter.leaf\"[label=\"leaf\"];}\n"
+                + "}\n"
+                + ""
+                + "\"one\"[label=\"one\"];}\n"
+                + ""
+                + "\"one\"->\"child.inter.leaf\"\n"
+                + ""
+                + "}";
+        //when
+        String report = dotFileFormat.renderReport();
+        //then
+        assertThat(report, is(expected));
+    }
+
     private Node<PackageData> getChildNodeByName(
             final Node<PackageData> baseNode,
             final String name) {

--- a/src/test/java/net/kemitix/dependency/digraph/maven/plugin/DotFileFormatNestedTest.java
+++ b/src/test/java/net/kemitix/dependency/digraph/maven/plugin/DotFileFormatNestedTest.java
@@ -82,7 +82,7 @@ public class DotFileFormatNestedTest {
 
         final String expected = "digraph{compound=true;node[shape=box]\n"
                 + "subgraph \"clustertest\"{"
-                + "label=\"test\";\"test\"[style=dotted]\n"
+                + "label=\"test\";\"test\"[label=\"test\",style=dotted]\n"
                 + "\"nested\"[label=\"nested\"];\"other\"[label=\"other\"];}\n"
                 + "\"nested\"->\"other\"\n"
                 + "}";
@@ -111,7 +111,7 @@ public class DotFileFormatNestedTest {
 
         final String expected = "digraph{compound=true;node[shape=box]\n"
                 + "subgraph \"clustertest\"{"
-                + "label=\"test\";\"test\"[style=dotted]\n"
+                + "label=\"test\";\"test\"[label=\"test\",style=dotted]\n"
                 + "\"nested\"[label=\"nested\"];}\n"
                 + "}";
         //when
@@ -139,7 +139,7 @@ public class DotFileFormatNestedTest {
 
         final String expected = "digraph{compound=true;node[shape=box]\n"
                 + "subgraph \"clustertest\"{"
-                + "label=\"test\";\"test\"[style=dotted]\n"
+                + "label=\"test\";\"test\"[label=\"test\",style=dotted]\n"
                 + "\"other\"[label=\"other\"];}\n"
                 + "}";
         //when
@@ -181,10 +181,10 @@ public class DotFileFormatNestedTest {
 
         final String expected = "digraph{compound=true;node[shape=box]\n"
                 + "subgraph \"clustertest\"{"
-                + "label=\"test\";\"test\"[style=dotted]\n"
+                + "label=\"test\";\"test\"[label=\"test\",style=dotted]\n"
                 + "\"nested\"[label=\"nested\"];"
                 + "subgraph \"clusterother\"{"
-                + "label=\"other\";\"other\"[style=dotted]\n"
+                + "label=\"other\";\"other\"[label=\"other\",style=dotted]\n"
                 + "\"other.more\"[label=\"more\"];}\n"
                 + "\"yetmore\"[label=\"yetmore\"];"
                 + "}\n"
@@ -234,10 +234,10 @@ public class DotFileFormatNestedTest {
         final String expected = "digraph{compound=true;node[shape=box]\n"
                 + ""
                 + "subgraph \"clustertest\"{"
-                + "label=\"test\";\"test\"[style=dotted]\n"
+                + "label=\"test\";\"test\"[label=\"test\",style=dotted]\n"
                 + ""
                 + "subgraph \"clusterchild\"{"
-                + "label=\"child\";\"child\"[style=dotted]\n"
+                + "label=\"child\";\"child\"[label=\"child\",style=dotted]\n"
                 + ""
                 + "subgraph \"clusterchild_inter\"{"
                 + "label=\"inter\";"


### PR DESCRIPTION
Packages contained with in another packge were being created with an Id that was just the leaf name of the package. For example, the package `net.kemitix.my.graph` would be called `graph`, when it should be `my.graph`. (assuming basePackage = `net.kemitix`)