### PR TITLE
Create target if needed

### DIFF
--- a/src/main/java/net/kemitix/dependency/digraph/maven/plugin/DefaultDigraphService.java
+++ b/src/main/java/net/kemitix/dependency/digraph/maven/plugin/DefaultDigraphService.java
@@ -28,6 +28,7 @@ import lombok.val;
 
 import javax.annotation.concurrent.Immutable;
 import javax.inject.Inject;
+import java.io.File;
 import java.io.IOException;
 
 /**
@@ -38,7 +39,7 @@ import java.io.IOException;
 @Immutable
 class DefaultDigraphService implements DigraphService {
 
-    private static final String REPORT_FILE = "target/digraph.dot";
+    private static final String REPORT_FILE = "digraph.dot";
 
     private final SourceDirectoryProvider directoryProvider;
 
@@ -92,8 +93,15 @@ class DefaultDigraphService implements DigraphService {
             dependencyData.debugLog(mojo.getLog());
         }
         try {
-            reportWriter.write(reportGenerator.generate(
-                    dotFileFormatFactory.create(mojo.getFormat(), dependencyData.getBaseNode())), REPORT_FILE);
+            val outputDirectory = new File(mojo.getProject()
+                                               .getBuild()
+                                               .getDirectory());
+            outputDirectory.mkdirs();
+            reportWriter.write(
+                    reportGenerator.generate(
+                            dotFileFormatFactory.create(mojo.getFormat(), dependencyData.getBaseNode())),
+                    new File(outputDirectory, REPORT_FILE).getAbsolutePath()
+                              );
         } catch (IOException ex) {
             mojo.getLog()
                 .error(ex.getMessage());

--- a/src/main/java/net/kemitix/dependency/digraph/maven/plugin/DigraphMojo.java
+++ b/src/main/java/net/kemitix/dependency/digraph/maven/plugin/DigraphMojo.java
@@ -25,6 +25,7 @@ SOFTWARE.
 package net.kemitix.dependency.digraph.maven.plugin;
 
 import com.google.inject.Guice;
+import lombok.Getter;
 import lombok.Setter;
 import lombok.val;
 import org.apache.maven.plugin.AbstractMojo;
@@ -32,6 +33,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
+import java.io.File;
 import java.util.List;
 
 /**
@@ -43,20 +45,35 @@ import java.util.List;
 public class DigraphMojo extends AbstractMojo {
 
     @Setter
+    @Getter
+    @Parameter(defaultValue = "${project}", readonly = true)
+    private MavenProject project;
+
+    @Setter
+    @Getter
     @Parameter(defaultValue = "${reactorProjects}", readonly = true)
     private List<MavenProject> projects;
 
+    @Setter
+    @Getter
+    @Parameter(defaultValue = "${project.outputDirectory}")
+    private File outputDirectory;
+
+    @Getter
     @Parameter(name = "includeTests", defaultValue = "false")
     private boolean includeTests;
 
     @Setter
+    @Getter
     @Parameter(name = "basePackage", required = true)
     private String basePackage;
 
+    @Getter
     @Parameter(name = "debug", defaultValue = "true")
     private boolean debug;
 
     @Setter
+    @Getter
     @Parameter(name = "format", defaultValue = "nested")
     private String format;
 
@@ -74,6 +91,6 @@ public class DigraphMojo extends AbstractMojo {
         val digraphModule = new DigraphModule(this, graphFilter);
         Guice.createInjector(digraphModule)
              .getInstance(DigraphService.class)
-             .execute(this, projects, includeTests, basePackage, format, debug);
+             .execute(this);
     }
 }

--- a/src/main/java/net/kemitix/dependency/digraph/maven/plugin/DigraphService.java
+++ b/src/main/java/net/kemitix/dependency/digraph/maven/plugin/DigraphService.java
@@ -24,11 +24,6 @@ SOFTWARE.
 
 package net.kemitix.dependency.digraph.maven.plugin;
 
-import org.apache.maven.plugin.AbstractMojo;
-import org.apache.maven.project.MavenProject;
-
-import java.util.List;
-
 /**
  * The Digraph Service.
  *
@@ -39,15 +34,7 @@ interface DigraphService {
     /**
      * Executes the Digraph service.
      *
-     * @param mojo         the parent mojo
-     * @param projects     the project(s) to analyse
-     * @param includeTests whether to include test code
-     * @param basePackage  the base package to scan
-     * @param format       the output format
-     * @param debug        whether debug output should be included
+     * @param mojo the parent mojo
      */
-    void execute(
-            AbstractMojo mojo, List<MavenProject> projects, boolean includeTests, String basePackage, String format,
-            boolean debug
-                );
+    void execute(DigraphMojo mojo);
 }

--- a/src/test/java/net/kemitix/dependency/digraph/maven/plugin/DefaultDigraphServiceTest.java
+++ b/src/test/java/net/kemitix/dependency/digraph/maven/plugin/DefaultDigraphServiceTest.java
@@ -1,10 +1,13 @@
 package net.kemitix.dependency.digraph.maven.plugin;
 
+import lombok.val;
 import org.apache.maven.model.Build;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -13,6 +16,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.doThrow;
 import static org.mockito.BDDMockito.given;
@@ -74,6 +78,9 @@ public class DefaultDigraphServiceTest {
     @Mock
     private Build build;
 
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
@@ -123,5 +130,19 @@ public class DefaultDigraphServiceTest {
         //then
         then(log).should()
                  .error(message);
+    }
+
+    @Test
+    public void createTargetDirectory() throws Exception {
+        //given
+        val target = folder.newFolder();
+        target.delete();
+        assertThat(target).doesNotExist();
+        given(build.getDirectory()).willReturn(target.getAbsolutePath());
+        //when
+        digraphService.execute(digraphMojo);
+        //then
+        assertThat(target).exists()
+                          .isDirectory();
     }
 }

--- a/src/test/java/net/kemitix/dependency/digraph/maven/plugin/DefaultDigraphServiceTest.java
+++ b/src/test/java/net/kemitix/dependency/digraph/maven/plugin/DefaultDigraphServiceTest.java
@@ -1,5 +1,6 @@
 package net.kemitix.dependency.digraph.maven.plugin;
 
+import org.apache.maven.model.Build;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.junit.Before;
@@ -67,6 +68,12 @@ public class DefaultDigraphServiceTest {
 
     private String format;
 
+    @Mock
+    private MavenProject project;
+
+    @Mock
+    private Build build;
+
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
@@ -79,19 +86,27 @@ public class DefaultDigraphServiceTest {
         mavenProjects = new ArrayList<>();
         format = "simple";
         includeTests = false;
+        given(digraphMojo.getBasePackage()).willReturn(basePackage);
+        given(digraphMojo.getProjects()).willReturn(mavenProjects);
+        given(digraphMojo.isIncludeTests()).willReturn(includeTests);
+        given(digraphMojo.isDebug()).willReturn(false);
+        given(digraphMojo.getProject()).willReturn(project);
+        given(project.getBuild()).willReturn(build);
+        given(build.getDirectory()).willReturn("target");
     }
 
     @Test
     public void execute() {
         //when
-        digraphService.execute(digraphMojo, mavenProjects, includeTests, basePackage, format, false);
+        digraphService.execute(digraphMojo);
     }
 
     @Test
     public void executeWithDebug() {
         //given
+        given(digraphMojo.isDebug()).willReturn(true);
         //when
-        digraphService.execute(digraphMojo, mavenProjects, includeTests, basePackage, format, true);
+        digraphService.execute(digraphMojo);
         //then
         then(digraphMojo).should()
                          .getLog();
@@ -104,7 +119,7 @@ public class DefaultDigraphServiceTest {
         doThrow(new IOException(message)).when(reportWriter)
                                          .write(any(), any());
         //when
-        digraphService.execute(digraphMojo, mavenProjects, includeTests, basePackage, format, false);
+        digraphService.execute(digraphMojo);
         //then
         then(log).should()
                  .error(message);

--- a/src/test/java/net/kemitix/dependency/digraph/maven/plugin/DigraphMojoTest.java
+++ b/src/test/java/net/kemitix/dependency/digraph/maven/plugin/DigraphMojoTest.java
@@ -1,9 +1,15 @@
 package net.kemitix.dependency.digraph.maven.plugin;
 
+import org.apache.maven.model.Build;
+import org.apache.maven.project.MavenProject;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 import java.util.ArrayList;
+
+import static org.mockito.BDDMockito.given;
 
 /**
  * Tests for {@link DigraphMojo}.
@@ -14,12 +20,22 @@ public class DigraphMojoTest {
 
     private DigraphMojo mojo;
 
+    @Mock
+    private MavenProject project;
+
+    @Mock
+    private Build build;
+
     @Before
     public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
         mojo = new DigraphMojo();
         mojo.setProjects(new ArrayList<>());
         // set defaults
         mojo.setFormat("nested");
+        mojo.setProject(project);
+        given(project.getBuild()).willReturn(build);
+        given(build.getDirectory()).willReturn("target");
     }
 
     @Test


### PR DESCRIPTION
* Don't die if the target directory doesn't exist
* Respects the ${build.directory} setting
* Tidy up invocation of `DigraphService#execute(...)`